### PR TITLE
Minor visual tweaks, avoid site styles breaking buttons

### DIFF
--- a/css/pwat.css
+++ b/css/pwat.css
@@ -9,6 +9,8 @@
     height: 39px;
     position: fixed;
     bottom: 0;
+    margin: 0;
+    padding: 0;
     color: #fff;
     font-size: .8em;
     font-family: "Helvetica Neue", Arial, sans-serif;


### PR DESCRIPTION
Using this module on a site based on Foundation, but site styles kept messing with PWAT buttons. This tweak fixes that issue for me, and as far as I can tell, there shouldn't be any (unexpected) side effects.